### PR TITLE
 fix: ctrl+c should quit 

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -37,21 +37,41 @@ async function main() {
     if (!input) {
       return;
     }
-    log.verb('You entered:', JSON.stringify(input));
-    if (!(input === 'r' || 'a' === input || 'q' === input)) {
-      return;
-    }
-    if('q' === input) {
-        process.exit(0);
-    }
-    if ('a' === input) {
-      resetEntireRequireCache();
-    }
-    try {
-      await run();
-      keyPressLog();
-    } catch (err) {
-      console.error(err);
+
+    log.verb(`You entered: ${input} (${JSON.stringify(input)})`);
+
+    const restart = async() => {
+      try {
+        await run();
+        keyPressLog();
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    const exit = () => {
+      log.verb('Exiting');
+      process.exit(0);
+    };
+
+    const inputMapFns = {
+      r: restart,
+      a: () => {
+        resetEntireRequireCache();
+        restart();
+      },
+      q: exit,
+      '♥': exit,
+      '\\u0003': exit,
+      '"\\u0003"': exit,
+    };
+
+    if (inputMapFns[input]) {
+      inputMapFns[input]()
+    } else if (inputMapFns[JSON.stringify(input)]) {
+      inputMapFns[JSON.stringify(input)]()
+    } else {
+      log.silly('Nothing to do for that input');
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -80,3 +80,11 @@ export default async function mochista(configArg) {
 
   return { watcher, mocha, onChange, run };
 }
+
+
+process.once('close', process.exit);
+process.once('exit', process.exit);
+process.once('uncaughtException', process.exit);
+process.once('SIGTERM', process.exit);
+process.once('SIGINT', process.exit);
+process.once('SIGHUP', process.exit);


### PR DESCRIPTION
Using `process.stdin.setRawMode(true)` prevents <kbd>Ctrl</kbd><kbd>C</kbd> from sending `SIGINT` signal. It is now handled in `onKeypress`.
